### PR TITLE
Changed pop method to accept an string or iterator of string as argument.

### DIFF
--- a/tempy/exceptions.py
+++ b/tempy/exceptions.py
@@ -52,3 +52,9 @@ class REPRError(TempyException):
 
 class IncompleteREPRError(REPRError, TypeError):
     """Raised when a TempyREPR subclass is not defined correctly."""
+
+class DOMModByIndexError(IndexError, TagError):
+    """Raised when wrong index is given to any DOM modification method"""
+
+class DOMModByKeyError(KeyError, TagError):
+    """Raised when wrong search key is given to any DOM modification method"""

--- a/tests/test_DOMElement.py
+++ b/tests/test_DOMElement.py
@@ -162,6 +162,15 @@ class TestDOMelement(unittest.TestCase):
         new2 = Div().append_to(self.page)
         self.page.pop()
         self.assertTrue(new2 not in self.page)
+        new3 = Div()
+        self.page._insert(new3, 'child_foo')
+        self.page.pop('child_foo')
+        self.assertTrue(new3 not in self.page)
+        new4, new5 = Div(), Div()
+        self.page._insert(new4, 'child_foo_1')
+        self.page._insert(new4, 'child_foo_2')        
+        self.page.pop(['child_foo_1', 'child_foo_2'])     
+        self.assertTrue(new4 not in self.page and new5 not in self.page)   
 
     def test_empty(self):
         new = Div().append_to(self.page)


### PR DESCRIPTION
Pop method now accepts an unique optional argument 'arg'. It can be an index, string or iterator of strings. If any argument is passed, the last child is removed.
Two new exception types are added for errors thrown in DOM modification methods.