### PR TITLE
Added render-list example

### DIFF
--- a/examples/templates/render_list.py
+++ b/examples/templates/render_list.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from tempy import Html, Head, Title, Body, Div, Content, Br, B, P
+
+words = ["These", "are", "all", "in", "seperate", "divs!",]
+
+page = Html()(
+    Head()(
+        Title()(
+            'Tempy - Render List'
+            )
+        ),
+    body=Body()(
+            *[Div()(w) for w in words]
+        )
+    )

--- a/examples/tempy_examples.py
+++ b/examples/tempy_examples.py
@@ -9,16 +9,21 @@ def none_handler():
     return 'Ready for some Tempy examples?'
 
 @app.route('/hello_world')
-def tempy_handler():
+def hello_world_handler():
     from templates.hello_world import page
     return page.render()
 
 @app.route('/star_wars')
-def tempy_handler():
+def star_wars_handler():
     from templates.star_wars import page
     with open('sw-people.json', 'r') as f:
         people = list(json.load(f).values())
     return page.render(characters=people)
+
+@app.route('/list')
+def render_list_handler():
+    from templates.render_list import page
+    return page.render()
 
 if __name__ == '__main__':
     app.run(port=8888, debug=False)


### PR DESCRIPTION
Added an example template that renders a list of words.
Also fixed a routing problem in the example server and added a new route to the list example.