### PR TITLE
Css extension

### DIFF
--- a/examples/templates/css_example.py
+++ b/examples/templates/css_example.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from tempy.tags import *
+from tempy.elements import Css
+
+my_text_list = ['This is Foo.', 'This is Bar.', 'Have you met my friend Baz?']
+another_list = ['Lorem ipsum ', 'dolor sit amet, ', 'consectetur adipiscing elit']
+
+div1 = Div(id='myid', klass='someHtmlClass')('dsfsd', Br())
+link = A()
+new_css = Css({'html': {
+        'body': {
+            'color': 'red',
+            Div: {
+                'color': 'green',
+                'border': '1px'
+            },
+           A: {'color': 'orange'}
+        }
+    },
+    '#myid': {'color': 'blue'}
+})
+
+new_css.replace_element(['#myid'], {'color': 'purple'})
+
+new_css.replace_element(['html', 'body', Div], {
+            'color': 'pink',
+            'a': {
+                'color': 'red'
+            }
+        })
+
+
+div2 = Div()
+div2.css(width='100px', float='left')
+div2.css({'height': '100em'})
+div2.css({'background-color': 'blue'})
+
+page = Html()(  # add tags inside the one you created calling the parent
+    Head()(  # add multiple tags in one call
+        Meta(charset='utf-8'),  # add tag attributes using kwargs in tag initialization
+        Link(href="my.css", typ="text/css", rel="stylesheet"),
+        new_css
+    ),
+    body=Body()(  # give them a name so you can navigate the DOM with those names
+        div1,
+        A(href="www.orange.com")
+    )
+)
+
+# add tags and content later
+page[1][0](A(href='www.bar.com'))  # calling the tag
+page[1][0].append(Br())  # using the API
+page[1][0].append(A(href='www.baz.com'))  # using the API
+page[1][0].append(Br())  # using the API
+link = A().append_to(page.body[0]) # access the body as if it's a page attribute
+page.body(testDiv=Div()) # WARNING! Correct ordering with named Tag insertion is ensured with Python >= 3.5 (because kwargs are ordered)
+link.attr(href='www.python.org')('This is a link to Python.') # Add attributes and content to already placed tags

--- a/examples/tempy_examples.py
+++ b/examples/tempy_examples.py
@@ -37,6 +37,11 @@ def table_handler():
     from templates.table_example import page
     return page.render()
 
+@app.route('/css')
+def css_handler():
+    from templates.css_example import page
+    return page.render()
+
 
 if __name__ == '__main__':
     app.run(port=8888, debug=True)

--- a/tempy/elements.py
+++ b/tempy/elements.py
@@ -10,7 +10,7 @@ from types import GeneratorType
 from collections import Mapping, Iterable, ChainMap
 
 from .tempy import DOMElement
-from .exceptions import WrongArgsError, WrongContentError, ContentError, TagError
+from .exceptions import WrongArgsError, WrongContentError, ContentError, TagError, AttrNotFoundError
 
 
 class TagAttrs(dict):
@@ -24,8 +24,8 @@ class TagAttrs(dict):
 
     TagAttrs.render formats all the attributes in the proper html format.
     """
-    _MAPPING_ATTRS = ('style', )
-    _SET_VALUES_ATTRS = ('klass', )
+    _MAPPING_ATTRS = ('style',)
+    _SET_VALUES_ATTRS = ('klass',)
     _SPECIALS = {
         'klass': 'class',
         'typ': 'type',
@@ -80,7 +80,7 @@ class TagAttrs(dict):
         for k, v in self.items():
             if v:
                 f_string = (' {}="{}"', ' {}')[v is bool]
-                f_args = (self._SPECIALS.get(k, k), self._FORMAT.get(k, lambda x: x)(v))[:2+(v is bool)]
+                f_args = (self._SPECIALS.get(k, k), self._FORMAT.get(k, lambda x: x)(v))[:2 + (v is bool)]
                 ret.append(f_string.format(*f_args))
         return ''.join(ret)
 
@@ -94,6 +94,7 @@ class TagAttrs(dict):
             if isinstance(v, str):
                 return '%s="""%s"""' % (k_norm, v)
             return '%s=%s' % (k_norm, v)
+
         twist_specials = {v: k for k, v in self._SPECIALS.items()}
         return ', '.join(formatter(k, v) for k, v in self.items() if v)
 
@@ -142,7 +143,7 @@ class Tag(DOMElement):
         css_repr = '%s%s' % (
             ' .css_class (%s)' % (self.attrs['class']) if self.attrs.get('class', None) else '',
             ' .css_id (%s)' % (self.attrs['id']) if self.attrs.get('id', None) else '',
-            )
+        )
         return super().__repr__()[:-1] + '%s>' % css_repr
 
     def __copy__(self):
@@ -311,7 +312,7 @@ class Css(Tag):
             }
         },
         '#myid': {'color': 'blue'}
-    }
+    })
     translates to:
     <style>
     html body {
@@ -385,6 +386,42 @@ class Css(Tag):
             file_to_write.write(self.render(**kwargs))
             self._template = '<style>{css}</style>'
 
+    def replace_element(self, element, new_style, ignore_error=True):
+        if new_style is None or not isinstance(new_style, dict) or not dict:
+            if ignore_error:
+                return
+            else:
+                raise WrongArgsError(self, new_style, 'Second argument should be a non-empty dictionary.')
+
+        try:
+            element_node = self.find_attr(element)
+        except (AttrNotFoundError, WrongArgsError) as wrong_args_error:
+            if ignore_error:
+                return
+            else:
+                print(wrong_args_error.__repr__())
+                raise
+
+        if element_node:
+            element_node[element.split()[-1]] = new_style
+        elif not element_node and element in self.attrs['css_attrs']:
+            self.attrs['css_attrs'] = new_style
+
+    def find_attr(self, element):
+        if not isinstance(element, str) or len(element) < 1:
+            raise WrongArgsError(self, element, 'Positional argument should be a non-empty string.')
+
+        found_node = self.attrs['css_attrs']
+        parent_node = None
+        elements_hierarchy = element.split()
+        for child in elements_hierarchy:
+            if child in found_node:
+                parent_node = found_node
+                found_node = found_node[child]
+            else:
+                raise AttrNotFoundError(self, element, 'Provided element does not exist in css attributes')
+        return parent_node
+
 
 class Content(DOMElement):
     """
@@ -393,6 +430,7 @@ class Content(DOMElement):
     If no content with the same name is used, an empty string is rendered.
     If instantiated with the named attribute content, this will override all the content injection on parents.
     """
+
     def __init__(self, name=None, content=None, t_repr=None):
         super().__init__()
         self._tab_count = 0

--- a/tempy/elements.py
+++ b/tempy/elements.py
@@ -13,6 +13,7 @@ from .tempy import DOMElement
 from .exceptions import WrongArgsError, WrongContentError, ContentError, TagError, AttrNotFoundError
 import inspect
 
+
 class TagAttrs(dict):
     """
     Html tag attributes container, a subclass of dict with __setitiem__ and update overload.

--- a/tempy/exceptions.py
+++ b/tempy/exceptions.py
@@ -60,3 +60,7 @@ class DOMModByIndexError(IndexError, TagError):
 
 class DOMModByKeyError(KeyError, TagError):
     """Raised when wrong search key is given to any DOM modification method"""
+
+
+class AttrNotFoundError(TempyException):
+    """Raised when css attribute is not found in css_attrs"""

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -99,10 +99,7 @@ class TestTag(unittest.TestCase):
     def test_render(self):
         css = Css(self.css_dict)
         rendered_css = css.render()
-        expected_counter = Counter('<style>html { background-color: lightblue; } h1 { color: white; text-align: center; } </style>')
-        expected_counter['{'] += 1
-        expected_counter['}'] += 1
-        expected_counter[' '] += 2
+        expected_counter = Counter('<style> {} html { background-color: lightblue; } h1 { color: white; text-align: center; } </style>')
         # We count chars occurrence 'cause in python < 3.6 kwargs is not an OrderedDict'
         self.assertEqual(Counter(rendered_css), expected_counter)
 
@@ -138,34 +135,34 @@ class TestTag(unittest.TestCase):
                         'color': 'green',
                         'border': '1px'
                     },
-                    link: {'color': 'purple'},
+                    link: {'color': 'grey'},
                     A: {'color': 'yellow'}
                 }
             },
-            '#myid': {'color': 'blue'}
+            '#myid': {'color': 'purple'}
         }
 
         css.replace_element(['#myid'], {'color': 'purple'})
         self.assertEqual({'color': 'purple'}, css.attrs['css_attrs']['#myid'])
 
         #nested example
-        # css.replace_element(['html', 'body', link], {'color': 'grey'})
-        # self.assertEqual({'color': 'grey'}, css.attrs['css_attrs']['html']['body'][link])
-        #
-        # #failed to find
-        # css.replace_element(['myid'], {'color': 'purple'})
-        # self.assertEqual({'color': 'purple'}, css.attrs['css_attrs']['#myid'])
-        # with self.assertRaises(AttrNotFoundError):
-        #     css.replace_element(['myid'], {'color': 'purple'}, ignore_error=False)
-        #
-        # #wrong args type
-        # css.replace_element('', None)
-        # self.assertEqual(css_values, css.attrs['css_attrs'])
-        # with self.assertRaises(WrongArgsError):
-        #     css.replace_element('', None, ignore_error=False)
-        #
-        # css.replace_element('', {'color': 'purple'})
-        # self.assertEqual(css_values, css.attrs['css_attrs'])
-        # with self.assertRaises(WrongArgsError):
-        #     css.replace_element('', {'color': 'purple'}, ignore_error=False)
+        css.replace_element(['html', 'body', link], {'color': 'grey'})
+        self.assertEqual({'color': 'grey'}, css.attrs['css_attrs']['html']['body'][link])
+
+        #failed to find
+        css.replace_element(['myid'], {'color': 'purple'})
+        self.assertEqual({'color': 'purple'}, css.attrs['css_attrs']['#myid'])
+        with self.assertRaises(AttrNotFoundError):
+            css.replace_element(['myid'], {'color': 'purple'}, ignore_error=False)
+
+        #wrong args type
+        css.replace_element('', None)
+        self.assertEqual(css_values, css.attrs['css_attrs'])
+        with self.assertRaises(WrongArgsError):
+            css.replace_element('', None, ignore_error=False)
+
+        css.replace_element('', {'color': 'purple'})
+        self.assertEqual(css_values, css.attrs['css_attrs'])
+        with self.assertRaises(WrongArgsError):
+            css.replace_element('', {'color': 'purple'}, ignore_error=False)
 

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -103,6 +103,27 @@ class TestTag(unittest.TestCase):
         # We count chars occurrence 'cause in python < 3.6 kwargs is not an OrderedDict'
         self.assertEqual(Counter(rendered_css), expected_counter)
 
+        link = A()
+        css_complex = Css({'html': {
+            'body': {
+                'color': 'red',
+                Div: {
+                    'color': 'green',
+                    'border': '1px'
+                },
+                link: {'color': 'grey'},
+                A: {'color': 'yellow'}
+            }
+        },
+            '#myid': {'color': 'purple'}
+        })
+        rendered_css = css_complex.render()
+        expected_css = '<style>{ } html { } #myid { color: purple; } html body { color: red; }' \
+                       ' html body div { color: green; border: 1px; } ' \
+                       'html body #85994352 { color: grey; } html body a { color: yellow; } </style>'
+        expected_counter = Counter(x for x in expected_css if not x.isdigit())
+        self.assertEqual(Counter(x for x in rendered_css if not x.isdigit()), expected_counter)
+
     def test_dump(self):
         css = Css({'div': {'color': 'blue'}})
         expected = '{ } div { color: blue; } '

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -104,6 +104,8 @@ class TestTag(unittest.TestCase):
         self.assertEqual(Counter(rendered_css), expected_counter)
 
         link = A()
+        link_with_id = A(id='ex_a')
+        link_with_class = A(klass='cl_a')
         css_complex = Css({'html': {
             'body': {
                 'color': 'red',
@@ -112,15 +114,19 @@ class TestTag(unittest.TestCase):
                     'border': '1px'
                 },
                 link: {'color': 'grey'},
+                link_with_class: {'color': 'grey'},
                 A: {'color': 'yellow'}
             }
         },
-            '#myid': {'color': 'purple'}
+            '#myid': {'color': 'purple'},
+            link_with_id: {'color': 'grey'},
+            'td, tr': {'color': 'pink'}
         })
         rendered_css = css_complex.render()
-        expected_css = '<style>{ } html { } #myid { color: purple; } html body { color: red; }' \
-                       ' html body div { color: green; border: 1px; } ' \
-                       'html body #85994352 { color: grey; } html body a { color: yellow; } </style>'
+        expected_css = '<style>{ } html { } #myid { color: purple; } #ex_a { color: grey; }' \
+                       ' td, tr { color: pink; } html body { color: red; } ' \
+                       'html body div { color: green; border: 1px; } html body #89602992 { color: grey; }' \
+                       ' html body .cl_a { color: grey; } html body a { color: yellow; } </style>'
         expected_counter = Counter(x for x in expected_css if not x.isdigit())
         self.assertEqual(Counter(x for x in rendered_css if not x.isdigit()), expected_counter)
 
@@ -187,3 +193,5 @@ class TestTag(unittest.TestCase):
         with self.assertRaises(WrongArgsError):
             css.replace_element('', {'color': 'purple'}, ignore_error=False)
 
+        css.replace_element(['html'], {'color': 'purple'})
+        self.assertEqual({'color': 'purple'}, css.attrs['css_attrs']['html'])


### PR DESCRIPTION
Resolving issues: #33, #44 (replace method), #50 
Including tests and examples.

I have come to the conclusion that the issue #33 isn't connected with fixing the init method, but only the rendering part, which I have implemented for the mentioned cases inside the issue. The only case I had to resolve is the last one mentioned in issue #33 and that is when provided an instance where it will be rendered with his tag name as the last fallback. This will not be correct since it will map it as if it were a Class case, it has to be tied to that specific instance. Because of this I tied it with the id(instance), which is unique.

The replace method has been added and works as seen in implemented example css_example.py.

If everything looks right, I'll add the clear method to this request.