### PR TITLE
Clear method 

### DIFF
--- a/tempy/elements.py
+++ b/tempy/elements.py
@@ -417,7 +417,7 @@ class Css(Tag):
         if element_node:
             element_node[selector_list[-1]] = new_style
         elif not element_node and selector_list[0] in self.attrs['css_attrs']:
-            self.attrs['css_attrs'] = new_style
+            (self.attrs['css_attrs'])[selector_list[0]] = new_style
 
     def find_attr(self, selector_list):
         if not isinstance(selector_list, list) or len(selector_list) < 1:
@@ -433,6 +433,25 @@ class Css(Tag):
             else:
                 raise AttrNotFoundError(self, selector_list, 'Provided element does not exist.')
         return parent_node
+
+    def clear(self, selector_list=None, ignore_error=True):
+        if selector_list is None:
+            self.attrs['css_attrs'] = {}
+            return
+
+        try:
+            element_node = self.find_attr(selector_list)
+        except (AttrNotFoundError, WrongArgsError) as wrong_args_error:
+            if ignore_error:
+                return
+            else:
+                print(wrong_args_error.__repr__())
+                raise
+
+        if element_node:
+            element_node.pop(selector_list[-1], None)
+        elif not element_node and selector_list[0] in self.attrs['css_attrs']:
+            (self.attrs['css_attrs']).pop([selector_list[0]], None)
 
 
 class Content(DOMElement):

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -195,3 +195,50 @@ class TestTag(unittest.TestCase):
 
         css.replace_element(['html'], {'color': 'purple'})
         self.assertEqual({'color': 'purple'}, css.attrs['css_attrs']['html'])
+
+    def test_clear(self):
+        link = A()
+        css = Css({'html': {
+            'body': {
+                'color': 'red',
+                Div: {
+                    'color': 'green',
+                    'border': '1px'
+                },
+                link: {'color': 'purple'},
+                A: {'color': 'yellow'}
+            }
+        },
+            '#myid': {'color': 'blue'}
+        })
+
+        css_values = {'html': {
+            'body': {
+                'color': 'red',
+                Div: {
+                    'color': 'green',
+                    'border': '1px'
+                },
+                link: {'color': 'purple'},
+                A: {'color': 'yellow'}
+            }
+        }
+        }
+
+        css.clear(['#myid'])
+        self.assertEqual(css_values, css.attrs['css_attrs'])
+
+        # failed to find
+        css.clear(['myid'])
+        self.assertEqual(css_values, css.attrs['css_attrs'])
+        with self.assertRaises(AttrNotFoundError):
+            css.clear(['myid'], ignore_error=False)
+
+        # wrong args type
+        css.clear('')
+        self.assertEqual(css_values, css.attrs['css_attrs'])
+        with self.assertRaises(WrongArgsError):
+            css.clear('', ignore_error=False)
+
+        css.clear()
+        self.assertEqual({}, css.attrs['css_attrs'])


### PR DESCRIPTION
Issue #44 

Clear method added. Same concept as the replace method where the first parameter is either the path list, or no parameter is provided (the whole css is deleted in that case). The second argument is the ignore_error argument which is by default true.