### PR TITLE
Add navigation to example home using TemPy

### DIFF
--- a/examples/templates/homepage.py
+++ b/examples/templates/homepage.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from tempy.tags import *
+
+examples = {"Hello World":"/hello_world", "Star Wars":"/star_wars",
+		"List":"/list", "Static Image":"/static", "Table":"/table", "CSS":"/css"}
+
+container = Div()(
+    'content: ', Div()('this is the content')
+)
+
+page = Html()(
+    Head()(
+        Title()(
+            'Tempy - Examples'
+            )
+        ),
+    body=Body()(
+		*[Div()(A(href=examples.get(k))(k)) for k in examples],
+       
+    )
+)

--- a/examples/tempy_examples.py
+++ b/examples/tempy_examples.py
@@ -7,17 +7,9 @@ app = Flask(__name__)
 
 @app.route('/')
 def none_handler():
-    return """Ready for some Tempy examples?
-   </br>
-   <ul>
-    <li><a href="/hello_world">Hello World</a></li>
-    <li><a href="/star_wars">Star Wars</a></li>
-    <li><a href="/list">List</a></li>
-    <li><a href="/static">Static Image</a></li>
-    <li><a href="/table">Table</a></li>
-    <li><a href="/css">CSS</a></li>
-    </ul>
-    """
+    from templates.homepage import page
+    return page.render() 
+
 
 @app.route('/hello_world')
 def hello_world_handler():
@@ -50,6 +42,11 @@ def table_handler():
 @app.route('/css')
 def css_handler():
     from templates.css_example import page
+    return page.render()
+
+@app.route('/homepage')
+def homepage_handler():
+    from templates.homepage import page
     return page.render()
 
 

--- a/examples/tempy_examples.py
+++ b/examples/tempy_examples.py
@@ -7,7 +7,17 @@ app = Flask(__name__)
 
 @app.route('/')
 def none_handler():
-    return 'Ready for some Tempy examples?'
+    return """Ready for some Tempy examples?
+   </br>
+   <ul>
+    <li><a href="/hello_world">Hello World</a></li>
+    <li><a href="/star_wars">Star Wars</a></li>
+    <li><a href="/list">List</a></li>
+    <li><a href="/static">Static Image</a></li>
+    <li><a href="/table">Table</a></li>
+    <li><a href="/css">CSS</a></li>
+    </ul>
+    """
 
 @app.route('/hello_world')
 def hello_world_handler():


### PR DESCRIPTION
This is a similar PR to #64 , but based on that conversation this update uses TemPy to load navigational links to other examples when the user navigates to ```/``` after running the tempy_examples.py script; this is in lieu of static HTML element tags, which the aforementioned PR used.