### PR TITLE
Added Tags/or instances of tags as keys for the CSS element init dict

### DIFF
--- a/tempy/elements.py
+++ b/tempy/elements.py
@@ -347,6 +347,16 @@ class Css(Tag):
             for parent in gen:
                 if isinstance(parent, tuple):
                     result.append(", ".join(parent))
+                elif isinstance(parent, Tag):
+                    if parent.id() != None:
+                        result.append("#"+str(parent.id()))
+                    elif len(parent.attrs["klass"]) > 0:
+                        out = ""
+                        for klass in parent.attrs["klass"]:
+                            out += "." + klass
+                        result.append(out)
+                    else:
+                        result.append(parent._get__tag() + " ")
                 elif inspect.isclass(parent):
                     result.append(
                         getattr(parent, "_" + parent.__name__ + "__tag") + " "


### PR DESCRIPTION
The following code allows the user to use Tag classes or an instance of a tag class as a value for a key in the init dict that the CSS class takes. As described/requested in issue: [https://github.com/Hrabal/TemPy/issues/33](https://github.com/Hrabal/TemPy/issues/33)