### PR TITLE
Remove keys method call in iteration context

### DIFF
--- a/tempy/__init__.py
+++ b/tempy/__init__.py
@@ -25,7 +25,7 @@ _shortcuts = {
 
 class Module(ModuleType):
     def __getattr__(self, name):
-        if name in _shortcuts.keys():
+        if name in _shortcuts:
             submodule = __import__(
                 "tempy." + _shortcuts[name], globals(), locals(), [name]
             )
@@ -58,7 +58,7 @@ sys.modules["tempy"].__dict__.update(
         "__path__": __path__,
         "__doc__": __doc__,
         "__version__": __version__,
-        "__all__": tuple(_shortcuts.keys()),
+        "__all__": tuple(_shortcuts),
         "__docformat__": "restructuredtext en",
     }
 )


### PR DESCRIPTION
`tuple` and `in` membership tests are considered iteration context. They will automatically call the `iter` function on _shortcuts (dict type) which returns her keys on the subsequent `next` call. Though harmless, it is extraneous.