### PR TITLE
Use ternary expression

### DIFF
--- a/tempy/t.py
+++ b/tempy/t.py
@@ -77,7 +77,7 @@ class TempyFactory:
             self.Void = TempyFactory(void_maker=True)
 
     def make_tempy(self, tage_name):
-        base_class = [Tag, VoidTag][self._void]
+        base_class = VoidTag if self._void else Tag
         return type(
             tage_name,
             (base_class, ),


### PR DESCRIPTION
The previous expression does not short circuit and it is overall archaic while the ternary expression is the standard recommendation for inline control flow implementation.